### PR TITLE
race.sh: change function definition syntax

### DIFF
--- a/race/race.sh
+++ b/race/race.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function racepart
+racepart()
 {
     input=$1
     echo $input > tmpfile


### PR DESCRIPTION
Since not all distros use bash as default sh, and the script uses
`function` which is a bashism.